### PR TITLE
Prevent duplicate covers from saving to savedCovers array

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -58,9 +58,10 @@ function createNewBook(event) {
 }
 
 function addCoverToSaved() {
-  savedCovers.push(currentCover);
-  console.log(savedCovers);
-}
+  if(!savedCovers.includes(currentCover)) {
+    savedCovers.push(currentCover);
+    }
+  }
 
 
 


### PR DESCRIPTION
Feature/ getting saving covers : prevent duplicates from going into saveCovers array.
Please review the main.js file for the addCoversToSaved function. It should prevent duplicates from going into the saved covers array.